### PR TITLE
add avrdude command for flashing cadet 1 firmware

### DIFF
--- a/cadet1/flash-firmware.command
+++ b/cadet1/flash-firmware.command
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# uses avrdude https://www.nongnu.org/avrdude/
+# and an AVR programmer like AVRISP-MKII
+avrdude -V -p m88p -c usbasp -P usb -B 1 -U flash:w:LZX-C1-SW-V1.0.elf -U efuse:w:0xF9:m -U hfuse:w:0xDF:m -U lfuse:w:0xFF:m


### PR DESCRIPTION
Command comes from [this post](https://community.lzxindustries.net/t/cadet-sync-generator-and-or-rgb-encoder-blues/1047/14). Hopefully this makes it easier to find the right fuse settings needed for programming the ATMEGA.